### PR TITLE
Add shared components

### DIFF
--- a/addon/components/atoms/drilldown-tr.js
+++ b/addon/components/atoms/drilldown-tr.js
@@ -1,0 +1,79 @@
+import Ember from 'ember'
+
+export default Ember.Component.extend({
+  tagName: 'tr',
+  classNameBindings: ['isOpen:dd-open', 'isClosed:dd-close'],
+  isOpen: null,
+  isClosed: null,
+  attributeBindings: ['level:data-level', 'hidden'],
+  level: 1,
+  hidden: Ember.computed('level', 'isOrphan', function() {
+    if (this.get('level') === 1) {
+      return null
+    }
+    return this.get('isOrphan') ? null : true
+  }),
+
+  didRender(...args) {
+    this._super(...args)
+    Ember.run.scheduleOnce('afterRender', this, 'setHasChild')
+    Ember.run.scheduleOnce('afterRender', this, 'setIsOrphan')
+  },
+
+  setHasChild() {
+    const hasChild = this.$().next('tr').data('level') > this.get('level')
+    this.set('hasChild', hasChild)
+    if (hasChild || this.get('loadData')) {
+      this.set('isClosed', true)
+    }
+  },
+
+  setIsOrphan() {
+    const parentLevel = this.get('level') - 1
+    const hasParent = this.$().prevAll(`tr[data-level="${parentLevel}"]`).get(0)
+    this.set('isOrphan', !hasParent)
+  },
+
+  click(event) {
+    if (!this.get('isOpen') && this.get('loadData')) {
+      if (this.get('isLoadingData')) { return }
+
+      this.set('isLoadingData', true)
+
+      return this.get('loadData')().then((result) => {
+        if (result !== false) {
+          this.set('hasChild', true)
+          return Ember.run.next(this, this._click, event)
+        }
+      }).finally(() => this.set('isLoadingData', false))
+    }
+
+    return this._click(event)
+  },
+
+  _click(event) {
+    const targetIsInput = Ember.$(event.target).is('input, select, button, a')
+    const isChildless = !this.get('hasChild')
+    if (isChildless || targetIsInput) {
+      // do not toggle if user focused on an input element and skip elements without children
+      return
+    }
+    const component = this
+    this.toggleProperty('isOpen')
+    this.$().nextAll('tr').each(function() {
+      const $el = Ember.$(this)
+      if ($el.data('level') <= component.get('level')) {
+        // break the loop if level is same or higher
+        return false
+      }
+      if ($el.data('level') > component.get('level')) {
+        const isClosing = $el.is(':visible')
+        if (isClosing || $el.data('level') === component.get('level') + 1) {
+          // close all higher level siblings and only show first level higher siblings
+          $el.prop('hidden', isClosing)
+        }
+      }
+    })
+    return true
+  }
+})

--- a/addon/components/molecules/amount-change.js
+++ b/addon/components/molecules/amount-change.js
@@ -1,0 +1,30 @@
+import Ember from 'ember'
+
+/**
+ * Molecule for representing a numeric value as either
+ * red (negative) or green (positive).
+ *
+ * Zero is not rendered by default, but it can with renderZero=true.
+ * Zero is rendered in default text color, which is currently black.
+ */
+export default Ember.Component.extend({
+  tagName: 'p',
+  renderZero: false,
+  classNameBindings: ['isPositive:text--plus', 'isNegative:text--minus'],
+
+  renderNumber: Ember.computed('{change,renderZero}', function() {
+    return this.get('renderZero') || this.get('change') !== 0
+  }),
+
+  change: Ember.computed('{new,old}', function() {
+    return this.get('new') - this.get('old')
+  }),
+
+  isPositive: Ember.computed('change', function() {
+    return this.get('change') > 0
+  }),
+
+  isNegative: Ember.computed('change', function() {
+    return this.get('change') < 0
+  })
+})

--- a/addon/components/molecules/diff-values.js
+++ b/addon/components/molecules/diff-values.js
@@ -1,0 +1,5 @@
+import Ember from 'ember'
+
+export default Ember.Component.extend({
+  tagName: ''
+})

--- a/addon/components/molecules/diff-values/value.js
+++ b/addon/components/molecules/diff-values/value.js
@@ -1,0 +1,5 @@
+import Ember from 'ember'
+
+export default Ember.Component.extend({
+  tagName: ''
+})

--- a/addon/templates/components/atoms/drilldown-tr.hbs
+++ b/addon/templates/components/atoms/drilldown-tr.hbs
@@ -1,0 +1,1 @@
+{{yield hasChild}}

--- a/addon/templates/components/molecules/amount-change.hbs
+++ b/addon/templates/components/molecules/amount-change.hbs
@@ -1,0 +1,3 @@
+{{#if renderNumber}}
+  {{to-locale-string change}}
+{{/if}}

--- a/addon/templates/components/molecules/diff-values.hbs
+++ b/addon/templates/components/molecules/diff-values.hbs
@@ -1,0 +1,6 @@
+<p>
+  {{molecules/diff-values/value value=new}}
+</p>
+<p class="text--light text--strike">
+  {{molecules/diff-values/value value=old}}
+</p>

--- a/addon/templates/components/molecules/diff-values/value.hbs
+++ b/addon/templates/components/molecules/diff-values/value.hbs
@@ -1,0 +1,5 @@
+{{#if value}}
+  {{value}}
+{{else}}
+  {{t 'no-value'}}
+{{/if}}

--- a/app/components/atoms/drilldown-tr.js
+++ b/app/components/atoms/drilldown-tr.js
@@ -1,0 +1,1 @@
+export { default } from 'echo-ember-common/components/atoms/drilldown-tr';

--- a/app/components/atoms/drilldown-tr.js
+++ b/app/components/atoms/drilldown-tr.js
@@ -1,1 +1,1 @@
-export { default } from 'echo-ember-common/components/atoms/drilldown-tr';
+export { default } from 'echo-ember-common/components/atoms/drilldown-tr'

--- a/app/components/molecules/amount-change.js
+++ b/app/components/molecules/amount-change.js
@@ -1,0 +1,1 @@
+export { default } from 'echo-ember-common/components/molecules/amount-change'

--- a/app/components/molecules/diff-values.js
+++ b/app/components/molecules/diff-values.js
@@ -1,1 +1,1 @@
-export { default } from 'echo-ember-common/components/molecules/diff-values';
+export { default } from 'echo-ember-common/components/molecules/diff-values'

--- a/app/components/molecules/diff-values.js
+++ b/app/components/molecules/diff-values.js
@@ -1,0 +1,1 @@
+export { default } from 'echo-ember-common/components/molecules/diff-values';

--- a/app/components/molecules/diff-values/value.js
+++ b/app/components/molecules/diff-values/value.js
@@ -1,1 +1,1 @@
-export { default } from 'echo-ember-common/components/molecules/diff-values/value';
+export { default } from 'echo-ember-common/components/molecules/diff-values/value'

--- a/app/components/molecules/diff-values/value.js
+++ b/app/components/molecules/diff-values/value.js
@@ -1,0 +1,1 @@
+export { default } from 'echo-ember-common/components/molecules/diff-values/value';

--- a/tests/integration/components/atoms/drilldown-tr-test.js
+++ b/tests/integration/components/atoms/drilldown-tr-test.js
@@ -1,0 +1,32 @@
+import { moduleForComponent, test } from 'ember-qunit'
+import hbs from 'htmlbars-inline-precompile'
+
+moduleForComponent('atoms/drilldown-tr', 'Integration | Component | atoms/drilldown tr', {
+  integration: true
+})
+
+/* eslint-disable no-magic-numbers */
+test('it renders', function(assert) {
+  // Template block usage:
+  this.render(hbs`
+    <table>
+    {{#atoms/drilldown-tr level=2}}<td>orphan lvl2</td>{{/atoms/drilldown-tr}}
+    {{#atoms/drilldown-tr level=1}}<td>lvl1</td>{{/atoms/drilldown-tr}}
+    {{#atoms/drilldown-tr level=2}}<td>lvl2</td>{{/atoms/drilldown-tr}}
+    {{#atoms/drilldown-tr level=3}}<td>lvl3</td>{{/atoms/drilldown-tr}}
+    {{#atoms/drilldown-tr level=2}}<td>lvl2</td>{{/atoms/drilldown-tr}}
+    </table>
+  `)
+
+  assert.equal(this.$('table tr:visible').length, 2, 'has only top level and orphan row initially shown')
+  assert.ok(this.$('table tr:visible td:contains(lvl1)').length, 'top level row initially shown')
+  assert.ok(this.$('table tr:visible td:contains(orphan lvl2)').length, 'orphan row initially shown')
+
+  this.$('td:contains(lvl1)').click()
+  assert.equal(this.$('table tr:visible').length, 4, 'shows next level when clicked')
+  assert.notOk(this.$('table tr:visible td:contains(lvl3)').length, 'shows next level when clicked')
+
+  this.$('td:contains(lvl2)').click()
+  assert.equal(this.$('table tr:visible').length, 5, 'shows last level when clicked')
+  assert.ok(this.$('table tr:visible td:contains(lvl3)').length, 'shows last level when clicked')
+})


### PR DESCRIPTION
this PR adds the following components extracted from echo-front for reuse in min-side:
- `drilldown-tr`
- `diff-values`
- `amount-change`