### PR TITLE
[GRAM-537] - prevent - Assertion Failed: calling set on destroyed object

### DIFF
--- a/addon/components/atoms/drilldown-tr.js
+++ b/addon/components/atoms/drilldown-tr.js
@@ -42,19 +42,19 @@ export default Ember.Component.extend({
 
       this.set('isLoadingData', true)
       this.toggleProperty('isOpen')
-
       try {
         const result = await this.get('loadData')()
-        if (result !== false) {
+        if (result !== false && !this.isDestroyed) {
           this.set('hasChild', true)
           return Ember.run.next(this, this._click, event)
         }
       } finally {
-        this.set('isLoadingData', false)
+        if (!this.isDestroyed) this.set('isLoadingData', false)
       }
     } else {
       this.toggleProperty('isOpen')
     }
+
     return this._click(event)
   },
 


### PR DESCRIPTION
# Summary
This PR fixes the issue, when clicking on a link in the `search-tab` in `echo-front` triggered an error. 
The issue was that we were trying to set a property on a component that did not existed anymore.

To prevent it from happening I added a check if the component still exist before setting the property.

Connected to:
https://github.com/gramo-org/echo/issues/3318
https://netguru.atlassian.net/browse/GRAM-537

This is also connected to `echo-front` PR that fixes the same issue on the component there https://github.com/gramo-org/echo-front/pull/1102

## Other
You reproduce it by:

Search for a recording
Click on the link of the recording to navigate to it's show page (the row will load it's data as the click() is called and toggle the isLoadingData property when done.
The page transitions away from search page and all drilldown-tr components are removed from DOM and the object is destroyed.
The request we initiated in step 2 returns and the code wants to toggle isLoadingData again.
You get this error "Assertion Failed: calling set on destroyed object: <echo-front@component:atoms/drilldown-tr::ember1141>.isLoadingData = false":

![image](https://user-images.githubusercontent.com/17565389/42151726-2bbc34de-7dde-11e8-8575-a63ae3d0ffac.png)

This error originates from drilldown-tr and the changing of the state of the component after it has been removed from DOM and thus destroyed.

That said, I don't think this bug originates from your pull request, nor your changes to drilldown component. I believe this bug may have been here before too, but I have not tried any previous version of master of echo front.

Maybe we have not noticed it before if we have never had the right combination: A drilldown-tr which loads data and has a link which makes the page transition away before the row is loaded. So this is the first combination which makes this issue apparent and it must be fixed :-)