### PR TITLE
tr-drilldown no longer data when checkbox and other inputs are being clicked.

### DIFF
--- a/addon/components/atoms/drilldown-tr.js
+++ b/addon/components/atoms/drilldown-tr.js
@@ -37,6 +37,8 @@ export default Ember.Component.extend({
   },
 
   async click(event) {
+    if (this.ignoreClickEvent(event)) return
+
     if (!this.get('isOpen') && this.get('loadData')) {
       if (this.get('isLoadingData')) { return }
 
@@ -59,14 +61,10 @@ export default Ember.Component.extend({
   },
 
   _click(event) {
-    const targetIsInput = Ember.$(event.target).is('input, select, button, a')
-    const isChildless = !this.get('hasChild')
+    if (this.ignoreClickEvent(event)) return
 
-    if (isChildless || targetIsInput) {
-      // do not toggle if user focused on an input element and skip elements without children
-      return
-    }
     const component = this
+
     this.$().nextAll('tr').each(function() {
       const $el = Ember.$(this)
       if ($el.data('level') <= component.get('level')) {
@@ -82,5 +80,13 @@ export default Ember.Component.extend({
       }
     })
     return true
+  },
+
+  ignoreClickEvent(event) {
+    const targetIsInput = Ember.$(event.target).is('input, select, button, a')
+    const isChildless = !this.get('hasChild')
+
+    // do not toggle if user focused on an input element and skip elements without children
+    return isChildless || targetIsInput
   }
 })


### PR DESCRIPTION
This change will ensure that tr-drilldown components no longer tries to load data or toggle open state if we click on an input element in row.

So, clicking on this check box will not load it's open-state-data from server:

![image](https://user-images.githubusercontent.com/92300/43905859-3c5865d8-9bf2-11e8-8eaa-0bc44d63f504.png)


See: https://github.com/gramo-org/echo-front/pull/1136