### PR TITLE
Add preventing input special characters for duration fields

### DIFF
--- a/addon/components/molecules/time-input/shared-input.js
+++ b/addon/components/molecules/time-input/shared-input.js
@@ -4,4 +4,13 @@ import layout from '../../../templates/components/molecules/time-input/shared-in
 export default Component.extend({
   layout,
   tagName: '',
+
+  actions: {
+    onlyNumbers() {
+      if (event.which < 48 || event.which > 57)
+      {
+        event.preventDefault()
+      }
+    }
+  }
 })

--- a/addon/components/molecules/time-input/shared-input.js
+++ b/addon/components/molecules/time-input/shared-input.js
@@ -7,10 +7,9 @@ export default Component.extend({
 
   actions: {
     onlyNumbers() {
-      if (event.which < 48 || event.which > 57)
-      {
-        event.preventDefault()
-      }
+      const ascii0 = 48
+      const ascii9 = 57
+      if (event.which < ascii0 || event.which > ascii9) event.preventDefault()
     }
   }
 })

--- a/addon/templates/components/molecules/time-input/shared-input.hbs
+++ b/addon/templates/components/molecules/time-input/shared-input.hbs
@@ -3,9 +3,12 @@
   <input
     data-test-time-input-type={{timeUnit}}
     oninput={{action (action changeAction timeUnit) value="target.value"}}
+    onkeypress={{action 'onlyNumbers'}}
     placeholder="--"
     value={{value}}
     type="number"
+    min="0"
+    step="1"
     class="form__input"
     disabled={{disabled}}
   >


### PR DESCRIPTION
### Description:
Add preventing input special characters in number fields. 
I had to add additional action to onkeypress for duration fields because type `number` allows to input specials characters like `+ - . ()` which should not happen here.

Related to https://github.com/gramo-org/echo-front/pull/1350#pullrequestreview-219409125